### PR TITLE
feat: add MacOS support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,8 @@ on: [pull_request]
 name: test
 jobs:
   test:
-    name: ${{ matrix.toolchain }} (${{ matrix.profile.name }})
-    runs-on: ubuntu-latest
+    name: ${{ matrix.platform }} ${{ matrix.toolchain }} (${{ matrix.profile.name }})
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -22,6 +22,9 @@ jobs:
           - beta
           - stable
           - 1.34.0
+        platform:
+          - ubuntu-latest
+          - macos-latest
         profile:
           - name: debug
           - name: release

--- a/README.md
+++ b/README.md
@@ -11,39 +11,48 @@ For example:
 
 ```rust
 use mmarinus::{Map, perms};
+use std::io::Read;
 
-let mut zero = std::fs::File::open("/dev/zero").unwrap();
+let mut hosts = std::fs::File::open("/etc/hosts").unwrap();
+
+let mut chunk = [0u8; 32];
+hosts.read_exact(&mut chunk).unwrap();
 
 let map = Map::bytes(32)
     .near(128 * 1024 * 1024)
-    .from(&mut zero, 0)
+    .from(&mut hosts, 0)
     .with(perms::Read)
     .unwrap();
 
-assert_eq!(&*map, &[0; 32]);
+assert_eq!(&*map, &chunk);
 ```
 
 You can also remap an existing mapping:
 
 ```rust
 use mmarinus::{Map, perms};
+use std::io::Read;
 
-let mut zero = std::fs::File::open("/dev/zero").unwrap();
+let mut hosts = std::fs::File::open("/etc/hosts").unwrap();
+
+let mut chunk = [0u8; 32];
+hosts.read_exact(&mut chunk).unwrap();
 
 let mut map = Map::bytes(32)
     .anywhere()
-    .from(&mut zero, 0)
+    .from(&mut hosts, 0)
     .with(perms::Read)
     .unwrap();
 
-assert_eq!(&*map, &[0; 32]);
+assert_eq!(&*map, &chunk);
 
 let mut map = map.remap()
-    .from(&mut zero, 0)
+    .from(&mut hosts, 0)
     .with(perms::ReadWrite)
     .unwrap();
 
-assert_eq!(&*map, &[0; 32]);
+assert_eq!(&*map, &chunk);
+
 for i in map.iter_mut() {
     *i = 255;
 }
@@ -54,20 +63,24 @@ Alternatively, you can just change the permissions:
 
 ```rust
 use mmarinus::{Map, perms};
+use std::io::Read;
 
-let mut zero = std::fs::File::open("/dev/zero").unwrap();
+let mut hosts = std::fs::File::open("/etc/hosts").unwrap();
 
-let mut map = Map::bytes(32)
-    .at(128 * 1024 * 1024)
-    .from(&mut zero, 0)
+let mut chunk = [0u8; 32];
+hosts.read_exact(&mut chunk).unwrap();
+
+let map = Map::bytes(32)
+    .near(128 * 1024 * 1024)
+    .from(&mut hosts, 0)
     .with(perms::Read)
     .unwrap();
 
-assert_eq!(&*map, &[0; 32]);
+assert_eq!(&*map, &chunk);
 
 let mut map = map.reprotect(perms::ReadWrite).unwrap();
+assert_eq!(&*map, &chunk);
 
-assert_eq!(&*map, &[0; 32]);
 for i in map.iter_mut() {
     *i = 255;
 }
@@ -79,7 +92,7 @@ Mapping a whole file into memory is easy:
 ```rust
 use mmarinus::{Map, Private, perms};
 
-let map = Map::load("/etc/os-release", Private, perms::Read).unwrap();
+let map = Map::load("/etc/hosts", Private, perms::Read).unwrap();
 ```
 
 License: Apache-2.0

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -14,6 +14,7 @@ pub trait Stage {}
 
 pub enum Address {
     None,
+    #[cfg(not(target_os = "macos"))]
     At(usize),
     Near(usize),
     Onto(usize),
@@ -59,6 +60,7 @@ impl<M> Builder<Size<M>> {
     /// Creates the mapping at the specified address
     ///
     /// This is equivalent to specifying an address with `MAP_FIXED_NOREPLACE` to `mmap()`.
+    #[cfg(not(target_os = "macos"))]
     #[inline]
     pub fn at(self, addr: usize) -> Builder<Destination<M>> {
         Builder(Destination {
@@ -191,6 +193,7 @@ impl<M, K: Kind> Builder<Source<M, K>> {
 
         let (addr, fixed) = match self.0.prev.addr {
             Address::None => (0, 0),
+            #[cfg(not(target_os = "macos"))]
             Address::At(a) if a != 0 => (a, libc::MAP_FIXED_NOREPLACE),
             Address::Near(a) if a != 0 => (a, 0),
             Address::Onto(a) if a != 0 => (a, libc::MAP_FIXED),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,39 +6,48 @@
 //!
 //! ```rust
 //! use mmarinus::{Map, perms};
+//! use std::io::Read;
 //!
-//! let mut zero = std::fs::File::open("/dev/zero").unwrap();
+//! let mut hosts = std::fs::File::open("/etc/hosts").unwrap();
+//!
+//! let mut chunk = [0u8; 32];
+//! hosts.read_exact(&mut chunk).unwrap();
 //!
 //! let map = Map::bytes(32)
 //!     .near(128 * 1024 * 1024)
-//!     .from(&mut zero, 0)
+//!     .from(&mut hosts, 0)
 //!     .with(perms::Read)
 //!     .unwrap();
 //!
-//! assert_eq!(&*map, &[0; 32]);
+//! assert_eq!(&*map, &chunk);
 //! ```
 //!
 //! You can also remap an existing mapping:
 //!
 //! ```rust
 //! use mmarinus::{Map, perms};
+//! use std::io::Read;
 //!
-//! let mut zero = std::fs::File::open("/dev/zero").unwrap();
+//! let mut hosts = std::fs::File::open("/etc/hosts").unwrap();
+//!
+//! let mut chunk = [0u8; 32];
+//! hosts.read_exact(&mut chunk).unwrap();
 //!
 //! let mut map = Map::bytes(32)
 //!     .anywhere()
-//!     .from(&mut zero, 0)
+//!     .from(&mut hosts, 0)
 //!     .with(perms::Read)
 //!     .unwrap();
 //!
-//! assert_eq!(&*map, &[0; 32]);
+//! assert_eq!(&*map, &chunk);
 //!
 //! let mut map = map.remap()
-//!     .from(&mut zero, 0)
+//!     .from(&mut hosts, 0)
 //!     .with(perms::ReadWrite)
 //!     .unwrap();
 //!
-//! assert_eq!(&*map, &[0; 32]);
+//! assert_eq!(&*map, &chunk);
+//!
 //! for i in map.iter_mut() {
 //!     *i = 255;
 //! }
@@ -49,20 +58,24 @@
 //!
 //! ```rust
 //! use mmarinus::{Map, perms};
+//! use std::io::Read;
 //!
-//! let mut zero = std::fs::File::open("/dev/zero").unwrap();
+//! let mut hosts = std::fs::File::open("/etc/hosts").unwrap();
 //!
-//! let mut map = Map::bytes(32)
-//!     .at(128 * 1024 * 1024)
-//!     .from(&mut zero, 0)
+//! let mut chunk = [0u8; 32];
+//! hosts.read_exact(&mut chunk).unwrap();
+//!
+//! let map = Map::bytes(32)
+//!     .near(128 * 1024 * 1024)
+//!     .from(&mut hosts, 0)
 //!     .with(perms::Read)
 //!     .unwrap();
 //!
-//! assert_eq!(&*map, &[0; 32]);
+//! assert_eq!(&*map, &chunk);
 //!
 //! let mut map = map.reprotect(perms::ReadWrite).unwrap();
+//! assert_eq!(&*map, &chunk);
 //!
-//! assert_eq!(&*map, &[0; 32]);
 //! for i in map.iter_mut() {
 //!     *i = 255;
 //! }
@@ -74,7 +87,7 @@
 //! ```rust
 //! use mmarinus::{Map, Private, perms};
 //!
-//! let map = Map::load("/etc/os-release", Private, perms::Read).unwrap();
+//! let map = Map::load("/etc/hosts", Private, perms::Read).unwrap();
 //! ```
 
 #![forbid(clippy::expect_used, clippy::panic)]

--- a/src/map.rs
+++ b/src/map.rs
@@ -309,4 +309,26 @@ mod tests {
         assert_eq!(l.size(), SIZE);
         assert_eq!(r.size(), 0);
     }
+
+    #[test]
+    fn huge() {
+        const SIZE: usize = 4 * 1024 * 1024;
+
+        let ret = Map::bytes(SIZE)
+            .anywhere()
+            .anonymously()
+            .with_huge_pages(0)
+            .with(perms::Read);
+
+        match ret {
+            Err(e) => {
+                // System might not have huge pages reserved by the admin
+                // ErrorKind::OutOfMemory was introduced in 1.54
+                if e.err.raw_os_error() != Some(12) {
+                    panic!("{}", e)
+                }
+            }
+            Ok(map) => assert_eq!(map.size(), SIZE),
+        }
+    }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -97,7 +97,7 @@ impl<K: Safe, T: Readable + Writeable> std::ops::DerefMut for Map<T, K> {
 impl<K: Safe, T: Readable> AsRef<[u8]> for Map<T, K> {
     #[inline]
     fn as_ref(&self) -> &[u8] {
-        &*self
+        self
     }
 }
 


### PR DESCRIPTION
Check it out. We're cross-platform.

A few tweaks were needed to make this work:

1) MacOS doesn't let you map character devices, so `/dev/zero` is no
   good for use in tests. `/etc/hosts` was the first file I thought of
   that would be guaranteed to exist and be user-readable.

2) `.at(addr)` uses `MAP_FIXED_NOREPLACE`, which doesn't exist (at least
   not with that name) in MacOS. There might be a way to make that work
   but for now it returns `InvalidInput` if you try to use it.

3) `.with_huge_pages(pow)` uses `MAP_HUGE_MASK` on linux, which also
   doesn't exist in MacOS. Luckily there's a vague equivalent in the
       VM_FLAGS_SUPERPAGE_SIZE stuff - except you don't get to choose the
       page size, and you apply those flags to the *fd* instead of passing
       them with the other flags.
    
And with that, mmarinus builds and all tests pass on MacOS. Fun!
    
[Harald Hoyer <harald@profian.com>]:
- adapted to current git HEAD
- also use VM_FLAGS_SUPERPAGE_SIZE_ANY
- extend CI for MacOS

Signed-off-by: Will Woods <will@profian.com>
Co-authored-by: Harald Hoyer <harald@profian.com>
Signed-off-by: Harald Hoyer <harald@profian.com>

Supersedes: https://github.com/enarx/mmarinus/pull/9

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
